### PR TITLE
커스텀 ESLint 룰 peelie/no-long-classname 추가

### DIFF
--- a/apps/peelie-web/eslint.config.js
+++ b/apps/peelie-web/eslint.config.js
@@ -22,6 +22,7 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      'peelie/no-long-classname': ['warn', { maxClasses: 5 }],
     },
   },
 );

--- a/apps/peelie-web/eslint.config.js
+++ b/apps/peelie-web/eslint.config.js
@@ -22,7 +22,7 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
-      'peelie/no-long-classname': ['warn', { maxClasses: 5 }],
+      'peelie/no-long-classname': ['warn', { maxClasses: 5, cnImportPath: '@/shared/lib/utils' }],
     },
   },
 );

--- a/apps/peelie-web/eslint.config.js
+++ b/apps/peelie-web/eslint.config.js
@@ -3,6 +3,7 @@ import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
+import peeliePlugin from '@peelie/eslint-plugin';
 
 export default tseslint.config(
   { ignores: ['dist', 'storybook-static'] },
@@ -16,6 +17,7 @@ export default tseslint.config(
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      peelie: peeliePlugin,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,

--- a/apps/peelie-web/package.json
+++ b/apps/peelie-web/package.json
@@ -89,7 +89,8 @@
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2",
     "vite-plugin-svgr": "^4.5.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@peelie/eslint-plugin": "workspace:*"
   },
   "msw": {
     "workerDirectory": [

--- a/apps/peelie-web/src/pages/AiChat/AiChatPage.tsx
+++ b/apps/peelie-web/src/pages/AiChat/AiChatPage.tsx
@@ -1,13 +1,14 @@
 import { useNavigate } from 'react-router-dom';
 import { SsgoiTransition } from '@ssgoi/react';
 import { Button } from '@/shared/ui/common/button';
+import { cn } from '@/shared/lib/utils';
 
 export default function AiChatPage() {
   const navigate = useNavigate();
 
   return (
     <SsgoiTransition id="/ai-chat">
-      <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      <div className={cn('flex flex-col items-center justify-center min-h-screen', 'gap-4')}>
         <h1 className="text-title-headline-1 text-gray-99">AI챗</h1>
         <Button color="tertiary" size="sm" onClick={() => navigate(-1)}>
           뒤로가기

--- a/apps/peelie-web/src/pages/Home/HomePage.tsx
+++ b/apps/peelie-web/src/pages/Home/HomePage.tsx
@@ -5,6 +5,7 @@ import PATH from '@/shared/constants/path';
 import ToggleSelect from '@/shared/ui/common/ToggleSelect/ToggleSelect';
 import Modal from '@/shared/ui/common/Modal/Modal';
 import { Button } from '@/shared/ui/common/button';
+import { cn } from '@/shared/lib/utils';
 
 export default function HomePage() {
   const [selected, setSelected] = useState('share');
@@ -12,7 +13,7 @@ export default function HomePage() {
 
   return (
     <SsgoiTransition id="/">
-      <div className="flex flex-col items-center justify-center min-h-screen gap-6 bg-amber-300">
+      <div className={cn('flex flex-col items-center justify-center min-h-screen', 'gap-6 bg-amber-300')}>
         <h1 className="heading-1-medium text-gray-99">Home</h1>
 
         <ToggleSelect

--- a/apps/peelie-web/src/pages/My/MyPage.tsx
+++ b/apps/peelie-web/src/pages/My/MyPage.tsx
@@ -1,13 +1,14 @@
 import { useNavigate } from 'react-router-dom';
 import { SsgoiTransition } from '@ssgoi/react';
 import { Button } from '@/shared/ui/common/button';
+import { cn } from '@/shared/lib/utils';
 
 export default function MyPage() {
   const navigate = useNavigate();
 
   return (
     <SsgoiTransition id="/my">
-      <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      <div className={cn('flex flex-col items-center justify-center min-h-screen', 'gap-4')}>
         <h1 className="text-title-headline-1 text-gray-99">마이페이지</h1>
         <Button color="tertiary" size="sm" onClick={() => navigate(-1)}>
           뒤로가기

--- a/apps/peelie-web/src/pages/Test/TestPage.tsx
+++ b/apps/peelie-web/src/pages/Test/TestPage.tsx
@@ -1,11 +1,12 @@
 import { Link } from 'react-router-dom';
 import { SsgoiTransition } from '@ssgoi/react';
 import PATH from '@/shared/constants/path';
+import { cn } from '@/shared/lib/utils';
 
 export default function TestPage() {
   return (
     <SsgoiTransition id="/test">
-      <div className="flex flex-col items-center justify-center min-h-screen gap-6 bg-amber-100">
+      <div className={cn('flex flex-col items-center justify-center min-h-screen', 'gap-6 bg-amber-100')}>
         <h1 className="heading-1-medium text-gray-99">Test Page</h1>
         <Link to={PATH.HOME} className="body-1-regular text-brand-100 underline">
           Go to Home

--- a/apps/peelie-web/src/shared/ui/common/ToggleSelect/ToggleSelect.tsx
+++ b/apps/peelie-web/src/shared/ui/common/ToggleSelect/ToggleSelect.tsx
@@ -25,7 +25,7 @@ export default function ToggleSelect({ items, value, onChange, className }: Togg
     >
       {/* 슬라이딩 인디케이터 */}
       <div
-        className="absolute top-[4px] bottom-[4px] rounded-full bg-gray-01 shadow-tooltip transition-transform duration-300 ease-out"
+        className={cn('absolute top-[4px] bottom-[4px] rounded-full bg-gray-01', 'shadow-tooltip transition-transform duration-300 ease-out')}
         style={{
           width: `calc((100% - 8px) / ${items.length})`,
           transform: `translateX(calc(${selectedIndex} * 100%))`,

--- a/packages/eslint-plugin-peelie/index.js
+++ b/packages/eslint-plugin-peelie/index.js
@@ -1,0 +1,3 @@
+export default {
+  rules: {},
+};

--- a/packages/eslint-plugin-peelie/index.js
+++ b/packages/eslint-plugin-peelie/index.js
@@ -1,3 +1,7 @@
+import noLongClassname from './rules/no-long-classname.js';
+
 export default {
-  rules: {},
+  rules: {
+    'no-long-classname': noLongClassname,
+  },
 };

--- a/packages/eslint-plugin-peelie/package.json
+++ b/packages/eslint-plugin-peelie/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@peelie/eslint-plugin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js"
+  },
+  "peerDependencies": {
+    "eslint": ">=9.0.0"
+  }
+}

--- a/packages/eslint-plugin-peelie/rules/no-long-classname.js
+++ b/packages/eslint-plugin-peelie/rules/no-long-classname.js
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview className string literal의 한 줄당 클래스 개수가 threshold를 넘으면 warn
+ */
+
+/**
+ * 문자열에서 줄 단위로 클래스 개수를 세고, 가장 많은 줄의 개수를 반환
+ * @param {string} str
+ * @returns {number}
+ */
+function countMaxClassesPerLine(str) {
+  const lines = str.split('\n');
+  let max = 0;
+  for (const line of lines) {
+    const count = line.trim().split(/\s+/).filter(Boolean).length;
+    if (count > max) max = count;
+  }
+  return max;
+}
+
+/**
+ * className 값 노드에서 string literal을 추출
+ * @param {import('estree').Node | null} valueNode
+ * @returns {{ str: string, literalNode: import('estree').Node } | null}
+ */
+function extractStringLiteral(valueNode) {
+  if (!valueNode) return null;
+
+  // Shape A: className="foo bar"
+  if (valueNode.type === 'Literal' && typeof valueNode.value === 'string') {
+    return { str: valueNode.value, literalNode: valueNode };
+  }
+
+  // Shape B: className={"foo bar"}
+  if (valueNode.type === 'JSXExpressionContainer') {
+    const expr = valueNode.expression;
+    if (expr.type === 'Literal' && typeof expr.value === 'string') {
+      return { str: expr.value, literalNode: expr };
+    }
+  }
+
+  return null;
+}
+
+export default {
+  meta: {
+    type: 'suggestion',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          maxClasses: { type: 'integer', minimum: 1 },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      tooMany:
+        'className has a line with {{count}} classes (max {{max}} per line).',
+    },
+  },
+
+  create(context) {
+    const { maxClasses = 5 } = context.options[0] ?? {};
+
+    return {
+      JSXAttribute(node) {
+        if (node.name.name !== 'className') return;
+        if (node.value === null) return;
+
+        const result = extractStringLiteral(node.value);
+        if (!result) return;
+
+        const count = countMaxClassesPerLine(result.str);
+        if (count > maxClasses) {
+          context.report({
+            node: result.literalNode,
+            messageId: 'tooMany',
+            data: { count: String(count), max: String(maxClasses) },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-peelie/rules/no-long-classname.js
+++ b/packages/eslint-plugin-peelie/rules/no-long-classname.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview className string literal의 한 줄당 클래스 개수가 threshold를 넘으면 warn
+ * @fileoverview className string literal의 한 줄당 클래스 개수가 threshold를 넘으면 warn + autofix
  */
 
 /**
@@ -41,14 +41,62 @@ function extractStringLiteral(valueNode) {
   return null;
 }
 
+/**
+ * 클래스 목록을 maxClasses개씩 그룹으로 분할
+ * @param {string} str
+ * @param {number} maxClasses
+ * @returns {string[]}
+ */
+function splitClasses(str, maxClasses) {
+  const classes = str.trim().split(/\s+/).filter(Boolean);
+  const groups = [];
+  for (let i = 0; i < classes.length; i += maxClasses) {
+    groups.push(classes.slice(i, i + maxClasses).join(' '));
+  }
+  return groups;
+}
+
+/**
+ * Program의 ImportDeclaration에서 cn import 상태 확인
+ * @param {import('estree').Program} programBody
+ * @param {string} cnImportPath
+ * @returns {{ hasCn: boolean, importNode: import('estree').Node | null, lastImportNode: import('estree').Node | null }}
+ */
+function findCnImport(programBody, cnImportPath) {
+  let matchingImport = null;
+  let lastImportNode = null;
+  let hasCn = false;
+
+  for (const node of programBody) {
+    if (node.type === 'ImportDeclaration') {
+      lastImportNode = node;
+      if (node.source.value === cnImportPath) {
+        matchingImport = node;
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported.name === 'cn'
+          ) {
+            hasCn = true;
+          }
+        }
+      }
+    }
+  }
+
+  return { hasCn, importNode: matchingImport, lastImportNode };
+}
+
 export default {
   meta: {
     type: 'suggestion',
+    fixable: 'code',
     schema: [
       {
         type: 'object',
         properties: {
           maxClasses: { type: 'integer', minimum: 1 },
+          cnImportPath: { type: ['string', 'null'] },
         },
         additionalProperties: false,
       },
@@ -60,7 +108,7 @@ export default {
   },
 
   create(context) {
-    const { maxClasses = 5 } = context.options[0] ?? {};
+    const { maxClasses = 5, cnImportPath = null } = context.options[0] ?? {};
 
     return {
       JSXAttribute(node) {
@@ -71,13 +119,69 @@ export default {
         if (!result) return;
 
         const count = countMaxClassesPerLine(result.str);
-        if (count > maxClasses) {
-          context.report({
-            node: result.literalNode,
-            messageId: 'tooMany',
-            data: { count: String(count), max: String(maxClasses) },
-          });
-        }
+        if (count <= maxClasses) return;
+
+        context.report({
+          node: result.literalNode,
+          messageId: 'tooMany',
+          data: { count: String(count), max: String(maxClasses) },
+          fix(fixer) {
+            const groups = splitClasses(result.str, maxClasses);
+            if (groups.length <= 1) return null;
+
+            // Mode A: 줄바꿈만 (cnImportPath 없음)
+            if (!cnImportPath) {
+              const newValue = groups.join('\n');
+              // Shape A: className="..." → 따옴표 유지
+              if (node.value.type === 'Literal') {
+                return fixer.replaceText(node.value, `"${newValue}"`);
+              }
+              // Shape B: className={"..."} → expression container 전체 교체
+              return fixer.replaceText(node.value, `{"${newValue}"}`);
+            }
+
+            // Mode B: cn() 래핑 (cnImportPath 설정됨)
+            const cnCall = `{cn(${groups.map((g) => `'${g}'`).join(', ')})}`;
+            const fixes = [fixer.replaceText(node.value, cnCall)];
+
+            // import 처리
+            const sourceCode = context.sourceCode;
+            const programBody = sourceCode.ast.body;
+            const { hasCn, importNode, lastImportNode } = findCnImport(
+              programBody,
+              cnImportPath,
+            );
+
+            if (!hasCn) {
+              if (importNode) {
+                // 같은 경로 import 있지만 cn 없음 → cn 추가
+                const lastSpecifier =
+                  importNode.specifiers[importNode.specifiers.length - 1];
+                fixes.push(
+                  fixer.insertTextAfter(lastSpecifier, ', cn'),
+                );
+              } else if (lastImportNode) {
+                // import 자체 없음 → 마지막 import 뒤에 삽입
+                fixes.push(
+                  fixer.insertTextAfter(
+                    lastImportNode,
+                    `\nimport { cn } from '${cnImportPath}';`,
+                  ),
+                );
+              } else {
+                // import가 하나도 없음 → 파일 맨 위에 삽입
+                fixes.push(
+                  fixer.insertTextBefore(
+                    programBody[0],
+                    `import { cn } from '${cnImportPath}';\n`,
+                  ),
+                );
+              }
+            }
+
+            return fixes;
+          },
+        });
       },
     };
   },

--- a/packages/eslint-plugin-peelie/rules/no-long-classname.js
+++ b/packages/eslint-plugin-peelie/rules/no-long-classname.js
@@ -126,21 +126,12 @@ export default {
           messageId: 'tooMany',
           data: { count: String(count), max: String(maxClasses) },
           fix(fixer) {
+            if (!cnImportPath) return null;
+
             const groups = splitClasses(result.str, maxClasses);
             if (groups.length <= 1) return null;
 
-            // Mode A: 줄바꿈만 (cnImportPath 없음)
-            if (!cnImportPath) {
-              const newValue = groups.join('\n');
-              // Shape A: className="..." → 따옴표 유지
-              if (node.value.type === 'Literal') {
-                return fixer.replaceText(node.value, `"${newValue}"`);
-              }
-              // Shape B: className={"..."} → expression container 전체 교체
-              return fixer.replaceText(node.value, `{"${newValue}"}`);
-            }
-
-            // Mode B: cn() 래핑 (cnImportPath 설정됨)
+            // cn() 래핑 (cnImportPath 설정됨)
             const cnCall = `{cn(${groups.map((g) => `'${g}'`).join(', ')})}`;
             const fixes = [fixer.replaceText(node.value, cnCall)];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@eslint/js':
         specifier: ^9.33.0
         version: 9.39.1
+      '@peelie/eslint-plugin':
+        specifier: workspace:*
+        version: link:../../packages/eslint-plugin-peelie
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -306,6 +309,12 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.10.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.0(@types/node@24.10.0)(typescript@5.8.3))(terser@5.44.1)(yaml@2.8.1)
+
+  packages/eslint-plugin-peelie:
+    dependencies:
+      eslint:
+        specifier: '>=9.0.0'
+        version: 9.39.1(jiti@2.6.1)
 
   packages/form:
     dependencies:


### PR DESCRIPTION
## Summary

- `@peelie/eslint-plugin` workspace 패키지 생성
- `className` string literal의 줄당 클래스 개수 초과 시 warn하는 `no-long-classname` 룰 구현
- `cnImportPath` 설정 시 `cn()` 래핑 autofix 지원, 미설정 시 warn만

## Detail

**감지 기준: 줄 단위 카운팅**
전체 클래스 수가 아닌 한 줄 기준 최대 클래스 개수로 판단. 가독성 문제의 본질이 "한 줄이 너무 긴 것"이기 때문.

**safe case만 autofix**
`className="..."`, `className={"..."}` (string literal)만 자동 수정. `cn()`, 조건부, 템플릿 리터럴 등 런타임 값이 개입되는 경우는 스킵.

**cnImportPath 분기**
`cn` 유틸이 없는 프로젝트에서도 감지 용도로 사용 가능하도록, autofix는 `cnImportPath` 설정 시에만 동작. import 자동 추가 포함.

**포매팅은 Prettier 위임**
autofix는 구조적으로 올바른 코드만 생성. lint-staged에서 `eslint --fix → prettier --write` 순으로 실행되므로 따옴표/줄바꿈/trailing comma는 Prettier가 처리.

## Test plan

- [x] `pnpm lint:web` — 위반 파일 6개 감지
- [x] `pnpm lint:web --fix` — cn() 래핑 + import 자동 추가 확인
- [x] autofix 후 재lint → warning 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)