### PR TITLE
Feat : 채팅방 내부 안정성 작업

### DIFF
--- a/.claude/hooks/fix-classnames.sh
+++ b/.claude/hooks/fix-classnames.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$CLAUDE_PROJECT_DIR"
+
+FILES=$(
+  { git diff --name-only --diff-filter=ACMR; \
+    git ls-files --others --exclude-standard; } \
+    | grep -E '\.(jsx|tsx)$' \
+    || true
+)
+
+[ -z "$FILES" ] && exit 0
+
+printf '%s\n' "$FILES" \
+  | tr '\n' '\0' \
+  | xargs -0 npx --no-install eslint \
+      --config "$CLAUDE_PROJECT_DIR/.claude/hooks/lint-classname.config.js" \
+      --no-config-lookup \
+      --fix

--- a/.claude/hooks/format-changed-files.sh
+++ b/.claude/hooks/format-changed-files.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$CLAUDE_PROJECT_DIR"
+
+FILES=$(
+  { git diff --name-only --diff-filter=ACMR; \
+    git ls-files --others --exclude-standard; } \
+    | grep -E '\.(js|jsx|ts|tsx|json|css|scss|md|mdx|yml|yaml)$' \
+    || true
+)
+
+[ -z "$FILES" ] && exit 0
+
+printf '%s\n' "$FILES" \
+  | tr '\n' '\0' \
+  | xargs -0 npx --no-install prettier --write --ignore-unknown --log-level=warn

--- a/.claude/hooks/lint-classname.config.js
+++ b/.claude/hooks/lint-classname.config.js
@@ -1,0 +1,30 @@
+import tseslint from 'typescript-eslint';
+
+import noLongClassname from '../../eslint-rules/no-long-classname.js';
+
+const classNamePlugin = {
+  rules: {
+    'no-long-classname': noLongClassname,
+  },
+};
+
+export default [
+  {
+    files: ['**/*.{ts,tsx,jsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        ecmaVersion: 2020,
+        sourceType: 'module',
+      },
+    },
+    plugins: { classname: classNamePlugin },
+    rules: {
+      'classname/no-long-classname': [
+        'warn',
+        { maxClasses: 9, cnImportPath: '@/shared/lib/utils' },
+      ],
+    },
+  },
+];

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/fix-classnames.sh",
+            "timeout": 30,
+            "statusMessage": "className 자동 줄임 중..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-changed-files.sh",
+            "timeout": 60,
+            "statusMessage": "변경된 파일 Prettier 포매팅 중..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+build
+.expo
+android
+ios
+*.lock
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/apps/peelie-web/src/app/layout/SsgoiLayout.tsx
+++ b/apps/peelie-web/src/app/layout/SsgoiLayout.tsx
@@ -7,18 +7,10 @@ import { NavigationBar } from '@/widgets/NavigationBar/NavigationBar';
 const NAV_ROUTES = ['/', '/ai-chat', '/my'];
 const NAV_ROUTE_SET = new Set<string>(NAV_ROUTES);
 
-function resetDocumentScroll() {
-  window.scrollTo(0, 0);
-
-  document.documentElement.scrollTop = 0;
-  document.documentElement.scrollLeft = 0;
-  document.body.scrollTop = 0;
-  document.body.scrollLeft = 0;
-}
-
 export default function SsgoiLayout() {
   const location = useLocation();
   const previousPathnameRef = useRef(location.pathname);
+  const routeScrollRef = useRef<HTMLDivElement>(null);
   const showNav = NAV_ROUTES.includes(location.pathname);
 
   const usePathname = useCallback(() => location.pathname, [location.pathname]);
@@ -32,7 +24,7 @@ export default function SsgoiLayout() {
       NAV_ROUTE_SET.has(previousPathname) &&
       NAV_ROUTE_SET.has(currentPathname)
     ) {
-      resetDocumentScroll();
+      routeScrollRef.current?.scrollTo({ top: 0, left: 0 });
     }
 
     previousPathnameRef.current = currentPathname;
@@ -44,6 +36,7 @@ export default function SsgoiLayout() {
         from: from.replace(/^\/chat-room\/[^/]+/, '/chat-room'),
         to: to.replace(/^\/chat-room\/[^/]+/, '/chat-room'),
       }),
+      experimentalPreserveScroll: true,
       transitions: [
         // 홈 <-> ai채팅
         {
@@ -102,14 +95,20 @@ export default function SsgoiLayout() {
       <div
         style={{
           position: 'relative',
-          minHeight: '100vh',
+          height: '100dvh',
           width: '100%',
-          overflowX: 'hidden',
+          overflow: 'hidden',
           background: 'transparent',
         }}
       >
-        <div className={showNav ? 'pb-12' : ''}>
-          <Outlet />
+        <div
+          id="route-scroll-container"
+          ref={routeScrollRef}
+          className="relative h-full overflow-y-auto overflow-x-hidden"
+        >
+          <div className={showNav ? 'pb-12' : ''}>
+            <Outlet />
+          </div>
         </div>
         {showNav && <NavigationBar className="fixed bottom-0 left-0 right-0" />}
       </div>

--- a/apps/peelie-web/src/app/main.tsx
+++ b/apps/peelie-web/src/app/main.tsx
@@ -3,17 +3,17 @@ import { createRoot } from 'react-dom/client';
 import AppRouter from './router/AppRouter';
 import '../global.css';
 
-if (process.env.NODE_ENV === 'development') {
-  const { worker } = await import('@/mocks/browers');
-  worker.start();
-}
+// if (process.env.NODE_ENV === 'development') {
+//   const { worker } = await import('@/mocks/browers');
+//   worker.start();
+// }
 
-if (import.meta.env.VITE_MSW_ENABLED === 'true') {
-  const { worker } = await import('@/mocks/browers');
-  await worker.start({
-    onUnhandledRequest: 'bypass',
-  });
-}
+// if (import.meta.env.VITE_MSW_ENABLED === 'true') {
+//   const { worker } = await import('@/mocks/browers');
+//   await worker.start({
+//     onUnhandledRequest: 'bypass',
+//   });
+// }
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/apps/peelie-web/src/entities/chatroom/api/chatroom.api.ts
+++ b/apps/peelie-web/src/entities/chatroom/api/chatroom.api.ts
@@ -5,6 +5,11 @@ import type { ChatListItem } from '../model/chatList.type';
 import type { ChatRoomListItem } from '../model/chatRoom.type';
 import type { ChatMessageListPayload } from '../model/chatMessage.type';
 
+export const chatroomPost = {
+  markRead: (chatRoomId: string): Promise<void> =>
+    api.post(`chatrooms/${chatRoomId}/read`).then(() => undefined),
+};
+
 export const chatroomGet = {
   /** AI 챗 페이지 — 전체 채팅방 목록 (preview + unread 포함). */
   getChatList: (): Promise<ApiResponse<ChatListItem[]>> =>

--- a/apps/peelie-web/src/entities/chatroom/api/index.ts
+++ b/apps/peelie-web/src/entities/chatroom/api/index.ts
@@ -1,3 +1,3 @@
-export { chatroomGet } from './chatroom.api';
+export { chatroomGet, chatroomPost } from './chatroom.api';
 export { chatroomQueries } from './chatroom.queries';
 export { ChatStreamPayloadError, parseChatStreamEvent } from './parseChatStreamEvent';

--- a/apps/peelie-web/src/entities/chatroom/hooks/index.ts
+++ b/apps/peelie-web/src/entities/chatroom/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useGetChatListQuery } from './useGetChatListQuery';
 export { useGetChatRoomsQuery } from './useGetChatRoomsQuery';
 export { useGetChatMessagesQuery } from './useGetChatMessagesQuery';
+export { useMarkReadMutation } from './useMarkReadMutation';

--- a/apps/peelie-web/src/entities/chatroom/hooks/useMarkReadMutation.ts
+++ b/apps/peelie-web/src/entities/chatroom/hooks/useMarkReadMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { chatroomPost } from '../api/chatroom.api';
+import { chatroomQueries } from '../api/chatroom.queries';
+
+export function useMarkReadMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (chatRoomId: string) => chatroomPost.markRead(chatRoomId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: chatroomQueries.chatList.queryKey });
+    },
+  });
+}

--- a/apps/peelie-web/src/entities/chatroom/model/index.ts
+++ b/apps/peelie-web/src/entities/chatroom/model/index.ts
@@ -1,4 +1,5 @@
 export type { PersonalityType } from './personality.type';
+export { PERSONALITY_LABEL } from './personality.type';
 export type { ChatListFriend, ChatListItem } from './chatList.type';
 export type { ChatRoomListFriend, ChatRoomListItem } from './chatRoom.type';
 export type { ChatRole, ChatBubble, ChatMessage, ChatMessageListPayload } from './chatMessage.type';

--- a/apps/peelie-web/src/entities/chatroom/model/personality.type.ts
+++ b/apps/peelie-web/src/entities/chatroom/model/personality.type.ts
@@ -5,3 +5,12 @@ export type PersonalityType =
   | 'ANALYTICAL_OBSERVER'
   | 'HEART_COLLECTOR'
   | 'STAGE_SETTER';
+
+export const PERSONALITY_LABEL: Record<PersonalityType, string> = {
+  STRAIGHT_SHOOTER: '직진 본능파',
+  ENERGETIC_TALKER: '불꽃 토커',
+  QUIET_CHARMER: '조용한 매력파',
+  ANALYTICAL_OBSERVER: '분석적 관찰자',
+  HEART_COLLECTOR: '하트 수집가',
+  STAGE_SETTER: '분위기 메이커',
+};

--- a/apps/peelie-web/src/entities/chatroom/ui/AvatarTypingBubble.tsx
+++ b/apps/peelie-web/src/entities/chatroom/ui/AvatarTypingBubble.tsx
@@ -4,12 +4,11 @@ import { cn } from '@/shared/lib/utils';
 interface AvatarTypingBubbleProps {
   /** 직전에 AvatarMessage 가 없는 경우(헤더 미표시 상황)에만 true 로 전달. */
   showHeader?: boolean;
+  name?: string;
   className?: string;
 }
 
-const BOT_NAME = 'POKI봇';
-
-export function AvatarTypingBubble({ showHeader, className }: AvatarTypingBubbleProps) {
+export function AvatarTypingBubble({ showHeader, name, className }: AvatarTypingBubbleProps) {
   return (
     <div className={cn('flex flex-col items-start gap-1', className)}>
       {showHeader && (
@@ -17,7 +16,7 @@ export function AvatarTypingBubble({ showHeader, className }: AvatarTypingBubble
           <div className="relative size-7 shrink-0 overflow-hidden rounded-full bg-gray-01">
             <ChatRoomProfileIcon className="absolute left-1.5 top-1 h-5 w-3.5" />
           </div>
-          <span className="text-body-s-400 text-brand-sub-30">{BOT_NAME}</span>
+          <span className="text-body-s-400 text-brand-sub-30">{name}</span>
         </div>
       )}
       <div className="pl-8">

--- a/apps/peelie-web/src/entities/chatroom/ui/AvatarTypingBubble.tsx
+++ b/apps/peelie-web/src/entities/chatroom/ui/AvatarTypingBubble.tsx
@@ -1,0 +1,44 @@
+import { ChatRoomProfileIcon } from '@/shared/ui/icons/ChatRoomProfileIcon';
+import { cn } from '@/shared/lib/utils';
+
+interface AvatarTypingBubbleProps {
+  /** 직전에 AvatarMessage 가 없는 경우(헤더 미표시 상황)에만 true 로 전달. */
+  showHeader?: boolean;
+  className?: string;
+}
+
+const BOT_NAME = 'POKI봇';
+
+export function AvatarTypingBubble({ showHeader, className }: AvatarTypingBubbleProps) {
+  return (
+    <div className={cn('flex flex-col items-start gap-1', className)}>
+      {showHeader && (
+        <div className="flex items-center gap-[7px]">
+          <div className="relative size-7 shrink-0 overflow-hidden rounded-full bg-gray-01">
+            <ChatRoomProfileIcon className="absolute left-1.5 top-1 h-5 w-3.5" />
+          </div>
+          <span className="text-body-s-400 text-brand-sub-30">{BOT_NAME}</span>
+        </div>
+      )}
+      <div className="pl-8">
+        <div
+          className="inline-flex items-center gap-1 rounded-small rounded-tl-none bg-brand-sub-30 px-3 py-3"
+          aria-label="응답 작성 중"
+        >
+          <Dot delay="0ms" />
+          <Dot delay="150ms" />
+          <Dot delay="300ms" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Dot({ delay }: { delay: string }) {
+  return (
+    <span
+      className="size-1.5 animate-bounce rounded-full bg-gray-70"
+      style={{ animationDelay: delay }}
+    />
+  );
+}

--- a/apps/peelie-web/src/entities/chatroom/ui/ChatInput.tsx
+++ b/apps/peelie-web/src/entities/chatroom/ui/ChatInput.tsx
@@ -33,7 +33,7 @@ export function ChatInput({
           <Input
             value={value}
             onChange={onChange}
-            placeholder="채팅을 보내보세요"
+            placeholder="직접 입력해보세요"
             disabled={disabled}
             className="w-full bg-transparent text-body-s-400 text-text-main outline-none placeholder:text-text-disabled disabled:opacity-60"
           />

--- a/apps/peelie-web/src/entities/chatroom/ui/ChatInput.tsx
+++ b/apps/peelie-web/src/entities/chatroom/ui/ChatInput.tsx
@@ -10,6 +10,7 @@ interface ChatInputProps {
   onRecommend?: () => void;
   /** 스트리밍 중 등 입력/전송 차단. */
   disabled?: boolean;
+  position?: 'fixed' | 'static';
   className?: string;
 }
 
@@ -19,6 +20,7 @@ export function ChatInput({
   onSubmit,
   onRecommend,
   disabled,
+  position = 'fixed',
   className,
 }: ChatInputProps) {
   const handleSubmit = () => {
@@ -27,7 +29,12 @@ export function ChatInput({
   };
 
   return (
-    <div className={cn('fixed bottom-0 left-0 right-0 px-5 py-2', className)}>
+    <div
+      className={cn(
+        position === 'fixed' ? 'fixed bottom-0 left-0 right-0 px-5 py-2' : 'px-5 py-2',
+        className,
+      )}
+    >
       <div className="rounded-[12px] border border-border-main bg-background-main px-4 py-3  bg-bg-main">
         <div className="flex flex-col gap-2">
           <Input

--- a/apps/peelie-web/src/entities/chatroom/ui/ChatRoomCard.tsx
+++ b/apps/peelie-web/src/entities/chatroom/ui/ChatRoomCard.tsx
@@ -1,20 +1,8 @@
 import { ChatItemIcon } from '@/shared/ui/icons/ChatItemIcon';
 import { cn } from '@/shared/lib/utils';
 
+import { PERSONALITY_LABEL } from '../model';
 import type { PersonalityType } from '../model';
-
-/**
- * personality → 한글 뱃지 라벨.
- * TODO: 디자인 확정 후 정확한 라벨로 교체.
- */
-const PERSONALITY_BADGE: Record<PersonalityType, string> = {
-  STRAIGHT_SHOOTER: '직진 본능파',
-  ENERGETIC_TALKER: '불꽃 토커',
-  QUIET_CHARMER: '조용한 매력파',
-  ANALYTICAL_OBSERVER: '분석적 관찰자',
-  HEART_COLLECTOR: '하트 수집가',
-  STAGE_SETTER: '분위기 메이커',
-};
 
 interface ChatRoomCardProps {
   userName: string;
@@ -56,7 +44,7 @@ export function ChatRoomCard({
                 'text-caption-m-400 text-gray-70',
               )}
             >
-              {PERSONALITY_BADGE[personality]}
+              {PERSONALITY_LABEL[personality]}
             </span>
             <span className="text-body-s-400 font-medium text-gray-99">{userName}</span>
           </div>

--- a/apps/peelie-web/src/entities/chatroom/ui/ChatRoomCard.tsx
+++ b/apps/peelie-web/src/entities/chatroom/ui/ChatRoomCard.tsx
@@ -38,8 +38,9 @@ export function ChatRoomCard({
     <button
       type="button"
       onClick={onClick}
-      className="flex w-full items-center gap-4 py-5 text-left"
+      className="group w-full rounded-2xl px-3 py-4 text-left active:bg-gray-30"
     >
+      <div className="flex items-center gap-4 transition-transform duration-150 group-active:scale-[0.97]">
       {/* 아바타 */}
       <div className="relative size-[46px] shrink-0 overflow-hidden rounded-full bg-gray-79">
         <ChatItemIcon className="absolute left-1/2 top-[9px] h-[46px] w-[33px] -translate-x-1/2" />
@@ -73,6 +74,7 @@ export function ChatRoomCard({
             {formatRelativeTime(lastMessageAt)}
           </span>
         </div>
+      </div>
       </div>
     </button>
   );

--- a/apps/peelie-web/src/entities/chatroom/ui/ChatRoomCard.tsx
+++ b/apps/peelie-web/src/entities/chatroom/ui/ChatRoomCard.tsx
@@ -41,40 +41,42 @@ export function ChatRoomCard({
       className="group w-full rounded-2xl px-3 py-4 text-left active:bg-gray-30"
     >
       <div className="flex items-center gap-4 transition-transform duration-150 group-active:scale-[0.97]">
-      {/* 아바타 */}
-      <div className="relative size-[46px] shrink-0 overflow-hidden rounded-full bg-gray-79">
-        <ChatItemIcon className="absolute left-1/2 top-[9px] h-[46px] w-[33px] -translate-x-1/2" />
-      </div>
+        {/* 아바타 */}
+        <div className="relative size-[46px] shrink-0 overflow-hidden rounded-full bg-gray-79">
+          <ChatItemIcon className="absolute left-1/2 top-[9px] h-[46px] w-[33px] -translate-x-1/2" />
+        </div>
 
-      {/* 콘텐츠 */}
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        {/* 뱃지 + 이름 + 안 읽음 도트 */}
-        <div className="flex items-center gap-2">
-          <span
-            className={cn(
-              'rounded-xsmall bg-brand-main px-[6px] py-[2px]',
-              'text-caption-m-400 text-gray-70',
-            )}
-          >
-            {PERSONALITY_BADGE[personality]}
-          </span>
-          <span className="text-body-s-400 font-medium text-gray-99">{userName}</span>
-          {isUnread && (
+        {/* 콘텐츠 */}
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          {/* 뱃지 + 이름 + 안 읽음 도트 */}
+          <div className="flex items-center gap-2">
             <span
-              aria-label="안 읽은 메시지 있음"
-              className="size-1.5 shrink-0 rounded-full bg-brand-sub-30"
-            />
-          )}
-        </div>
+              className={cn(
+                'rounded-xsmall bg-brand-main px-[6px] py-[2px]',
+                'text-caption-m-400 text-gray-70',
+              )}
+            >
+              {PERSONALITY_BADGE[personality]}
+            </span>
+            <span className="text-body-s-400 font-medium text-gray-99">{userName}</span>
+          </div>
 
-        {/* 미리보기 + 시간 */}
-        <div className="flex items-center justify-between gap-3 whitespace-nowrap">
-          <p className="truncate text-caption-m-400 text-gray-99">{lastMessage ?? ''}</p>
-          <span className="shrink-0 text-caption-m-400 text-text-disabled">
-            {formatRelativeTime(lastMessageAt)}
-          </span>
+          {/* 미리보기 + 시간 */}
+          <div className="flex items-center justify-between gap-5 whitespace-nowrap">
+            <p className="truncate text-caption-m-400 text-gray-99">{lastMessage ?? ''}</p>
+            <div className="relative shrink-0">
+              <span className="text-caption-m-400 text-text-disabled">
+                {formatRelativeTime(lastMessageAt)}
+              </span>
+              {isUnread && (
+                <span
+                  aria-label="안 읽은 메시지 있음"
+                  className="absolute left-[calc(100%+4px)] top-3.25 size-1.5 -translate-y-1/2 rounded-full bg-brand-main"
+                />
+              )}
+            </div>
+          </div>
         </div>
-      </div>
       </div>
     </button>
   );

--- a/apps/peelie-web/src/entities/chatroom/ui/ChatRoomCard.tsx
+++ b/apps/peelie-web/src/entities/chatroom/ui/ChatRoomCard.tsx
@@ -52,14 +52,14 @@ export function ChatRoomCard({
           {/* 미리보기 + 시간 */}
           <div className="flex items-center justify-between gap-5 whitespace-nowrap">
             <p className="truncate text-caption-m-400 text-gray-99">{lastMessage ?? ''}</p>
-            <div className="relative shrink-0">
+            <div className="relative shrink-0 flex items-center">
               <span className="text-caption-m-400 text-text-disabled">
                 {formatRelativeTime(lastMessageAt)}
               </span>
               {isUnread && (
                 <span
                   aria-label="안 읽은 메시지 있음"
-                  className="absolute left-[calc(100%+4px)] top-3.25 size-1.5 -translate-y-1/2 rounded-full bg-brand-main"
+                  className="absolute left-[calc(100%+4px)] top-2.25 size-1.5 -translate-y-1/2 rounded-full bg-brand-main"
                 />
               )}
             </div>

--- a/apps/peelie-web/src/entities/chatroom/ui/index.ts
+++ b/apps/peelie-web/src/entities/chatroom/ui/index.ts
@@ -1,4 +1,5 @@
 export * from './AvatarBubble';
+export * from './AvatarTypingBubble';
 export * from './UserBubble';
 export * from './DateSeparator';
 export * from './ChatInput';

--- a/apps/peelie-web/src/entities/chatroom/utils/buildRenderItems.ts
+++ b/apps/peelie-web/src/entities/chatroom/utils/buildRenderItems.ts
@@ -3,7 +3,8 @@ import type { ChatBubble, ChatMessage, LocalTurn } from '../model';
 export type RenderItem =
   | { kind: 'message'; message: ChatMessage; isLastAvatarTurn: boolean }
   | { kind: 'streaming-user'; text: string; createdAt: string }
-  | { kind: 'streaming-avatar'; bubbles: ChatBubble[]; suggestions: string[]; createdAt: string };
+  | { kind: 'streaming-avatar'; bubbles: ChatBubble[]; suggestions: string[]; createdAt: string }
+  | { kind: 'streaming-placeholder'; showHeader: boolean; createdAt: string };
 
 export type StreamingState =
   | { kind: 'none' }
@@ -15,6 +16,8 @@ interface BuildArgs {
   greetingTurn: LocalTurn | null;
   history: LocalTurn[];
   streaming: StreamingState;
+  /** greeting 진행 중 (suggestions 도착 전) 여부. true 면 마지막에 placeholder 추가. */
+  greetingPending?: boolean;
   /** "지금" 시각. 매 호출마다 새로 만들면 buildRenderItems 결과가 매 호출 달라져
    *  React 가 불필요한 리렌더 키 변경을 감지할 수 있어, 호출부에서 한 번만 만들어 넘긴다. */
   nowIso: string;
@@ -25,6 +28,7 @@ export function buildRenderItems({
   greetingTurn,
   history,
   streaming,
+  greetingPending,
   nowIso,
 }: BuildArgs): RenderItem[] {
   const flat: ChatMessage[] = [];
@@ -86,6 +90,18 @@ export function buildRenderItems({
       createdAt: nowIso,
     });
   }
+
+  const sendPending =
+    streaming.kind === 'sending' ||
+    (streaming.kind === 'streaming' && streaming.suggestions.length === 0);
+  if (sendPending || greetingPending) {
+    const hasStreamingAvatar = streaming.kind === 'streaming' && streaming.bubbles.length > 0;
+    items.push({
+      kind: 'streaming-placeholder',
+      showHeader: !hasStreamingAvatar,
+      createdAt: nowIso,
+    });
+  }
   return items;
 }
 
@@ -95,6 +111,7 @@ export function getRenderItemCreatedAt(item: RenderItem): string {
       return item.message.createdAt;
     case 'streaming-user':
     case 'streaming-avatar':
+    case 'streaming-placeholder':
       return item.createdAt;
   }
 }
@@ -107,5 +124,7 @@ export function getRenderItemKey(item: RenderItem, index: number): string {
       return `streaming-user-${index}`;
     case 'streaming-avatar':
       return `streaming-avatar-${index}`;
+    case 'streaming-placeholder':
+      return `streaming-placeholder-${index}`;
   }
 }

--- a/apps/peelie-web/src/features/chatroom/hooks/index.ts
+++ b/apps/peelie-web/src/features/chatroom/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useSendChatMessage } from './useSendChatMessage';
 export { useGreeting } from './useGreeting';
+export { useMarkRead } from './useMarkRead';

--- a/apps/peelie-web/src/features/chatroom/hooks/useGreeting.ts
+++ b/apps/peelie-web/src/features/chatroom/hooks/useGreeting.ts
@@ -1,74 +1,16 @@
-import { useEffect, useRef, useState } from 'react';
-import { toast } from 'sonner';
+import { useEffect, useSyncExternalStore } from 'react';
 
-import type { ChatBubble, LocalTurn } from '@/entities/chatroom';
+import { greetingStore, startGreeting } from '../model/greetingStore';
 
-import { streamGreeting } from '../api/streamGreeting';
-
-/**
- * 채팅방 진입 시 선제 인사 SSE 호출.
- * BE 가 lastEnteredAt KST 비교로 skip 판단하므로 매번 호출해도 안전.
- * V1 에선 streaming 중간 상태는 화면에 노출하지 않고, 완료된 turn 만 반환한다.
- */
 export function useGreeting(chatRoomId: string) {
-  const [turn, setTurn] = useState<LocalTurn | null>(null);
-  const [pending, setPending] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
+  const snapshot = useSyncExternalStore(greetingStore.subscribe, greetingStore.getSnapshot);
 
   useEffect(() => {
     if (!chatRoomId) return;
-    const controller = new AbortController();
-    abortRef.current = controller;
-    setPending(true);
-
-    const acc = { bubbles: [] as ChatBubble[], suggestions: [] as string[] };
-    let completed: LocalTurn | null = null;
-    let skipped = false;
-
-    streamGreeting(
-      chatRoomId,
-      (event) => {
-        switch (event.type) {
-          case 'skip':
-            skipped = true;
-            return;
-          case 'meta':
-            return;
-          case 'bubble':
-            acc.bubbles.push({ text: event.text, delayMs: event.delayMs });
-            return;
-          case 'suggestions':
-            acc.suggestions = event.suggestions;
-            return;
-          case 'done':
-            completed = {
-              kind: 'greeting',
-              bubbles: acc.bubbles,
-              suggestions: acc.suggestions,
-              completedAt: new Date().toISOString(),
-            };
-            return;
-          case 'error':
-            toast.error(event.message);
-            return;
-        }
-      },
-      controller.signal,
-    )
-      .catch((e) => {
-        if (controller.signal.aborted) return;
-        toast.error(e instanceof Error ? e.message : '인사 로딩 실패');
-      })
-      .finally(() => {
-        if (controller.signal.aborted) return;
-        setPending(false);
-        if (!skipped && completed) {
-          setTurn(completed);
-        }
-      });
-
-    return () => controller.abort();
+    startGreeting(chatRoomId);
   }, [chatRoomId]);
 
-  return { turn, pending };
+  const entry = snapshot.get(chatRoomId) ?? { turn: null, pending: false };
+
+  return { turn: entry.turn, pending: entry.pending };
 }

--- a/apps/peelie-web/src/features/chatroom/hooks/useGreeting.ts
+++ b/apps/peelie-web/src/features/chatroom/hooks/useGreeting.ts
@@ -12,12 +12,14 @@ import { streamGreeting } from '../api/streamGreeting';
  */
 export function useGreeting(chatRoomId: string) {
   const [turn, setTurn] = useState<LocalTurn | null>(null);
+  const [pending, setPending] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     if (!chatRoomId) return;
     const controller = new AbortController();
     abortRef.current = controller;
+    setPending(true);
 
     const acc = { bubbles: [] as ChatBubble[], suggestions: [] as string[] };
     let completed: LocalTurn | null = null;
@@ -59,6 +61,7 @@ export function useGreeting(chatRoomId: string) {
       })
       .finally(() => {
         if (controller.signal.aborted) return;
+        setPending(false);
         if (!skipped && completed) {
           setTurn(completed);
         }
@@ -67,5 +70,5 @@ export function useGreeting(chatRoomId: string) {
     return () => controller.abort();
   }, [chatRoomId]);
 
-  return { turn };
+  return { turn, pending };
 }

--- a/apps/peelie-web/src/features/chatroom/hooks/useMarkRead.ts
+++ b/apps/peelie-web/src/features/chatroom/hooks/useMarkRead.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { chatroomPost, chatroomQueries } from '@/entities/chatroom';
+import type { LocalTurn } from '@/entities/chatroom';
+
+interface UseMarkReadOptions {
+  chatRoomId: string;
+  /** useSendChatMessage 의 history.length — 스트림 완료마다 증가 */
+  historyLength: number;
+  /** useGreeting 의 turn — greeting 완료 시 null → LocalTurn */
+  greetingTurn: LocalTurn | null;
+}
+
+export function useMarkRead({ chatRoomId, historyLength, greetingTurn }: UseMarkReadOptions) {
+  const queryClient = useQueryClient();
+
+  const fire = useCallback(() => {
+    chatroomPost.markRead(chatRoomId).catch(() => {});
+    queryClient.invalidateQueries({ queryKey: chatroomQueries.chatList.queryKey });
+  }, [chatRoomId, queryClient]);
+
+  // 메시지 스트림 완료 시
+  const prevHistoryLengthRef = useRef(historyLength);
+  useEffect(() => {
+    if (historyLength > prevHistoryLengthRef.current && !document.hidden) {
+      fire();
+    }
+    prevHistoryLengthRef.current = historyLength;
+  }, [historyLength, fire]);
+
+  // greeting 완료 시
+  const prevTurnRef = useRef(greetingTurn);
+  useEffect(() => {
+    if (!prevTurnRef.current && greetingTurn && !document.hidden) {
+      fire();
+    }
+    prevTurnRef.current = greetingTurn;
+  }, [greetingTurn, fire]);
+
+  // 채팅방 unmount 시 (chatRoomId ref 사용 — stale closure 방지)
+  const chatRoomIdRef = useRef(chatRoomId);
+  chatRoomIdRef.current = chatRoomId;
+  useEffect(() => {
+    return () => {
+      chatroomPost.markRead(chatRoomIdRef.current).catch(() => {});
+    };
+  }, []);
+
+  // 탭/앱 백그라운드 전환 시
+  useEffect(() => {
+    const handler = () => {
+      if (document.visibilityState === 'hidden') {
+        chatroomPost.markRead(chatRoomId).catch(() => {});
+      }
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, [chatRoomId]);
+}

--- a/apps/peelie-web/src/features/chatroom/hooks/useMarkRead.ts
+++ b/apps/peelie-web/src/features/chatroom/hooks/useMarkRead.ts
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useRef } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
 
-import { chatroomPost, chatroomQueries } from '@/entities/chatroom';
+import { chatroomPost, chatroomQueries, useMarkReadMutation } from '@/entities/chatroom';
 import type { LocalTurn } from '@/entities/chatroom';
+import { queryClient } from '@/shared/config/quertClient';
 
 interface UseMarkReadOptions {
   chatRoomId: string;
@@ -12,38 +12,40 @@ interface UseMarkReadOptions {
   greetingTurn: LocalTurn | null;
 }
 
-export function useMarkRead({ chatRoomId, historyLength, greetingTurn }: UseMarkReadOptions) {
-  const queryClient = useQueryClient();
+function invalidateChatList() {
+  queryClient.invalidateQueries({ queryKey: chatroomQueries.chatList.queryKey });
+}
 
-  const fire = useCallback(() => {
-    chatroomPost.markRead(chatRoomId).catch(() => {});
-    queryClient.invalidateQueries({ queryKey: chatroomQueries.chatList.queryKey });
-  }, [chatRoomId, queryClient]);
+export function useMarkRead({ chatRoomId, historyLength, greetingTurn }: UseMarkReadOptions) {
+  const { mutate } = useMarkReadMutation();
 
   // 메시지 스트림 완료 시
   const prevHistoryLengthRef = useRef(historyLength);
   useEffect(() => {
     if (historyLength > prevHistoryLengthRef.current && !document.hidden) {
-      fire();
+      mutate(chatRoomId);
     }
     prevHistoryLengthRef.current = historyLength;
-  }, [historyLength, fire]);
+  }, [historyLength, chatRoomId, mutate]);
 
   // greeting 완료 시
   const prevTurnRef = useRef(greetingTurn);
   useEffect(() => {
     if (!prevTurnRef.current && greetingTurn && !document.hidden) {
-      fire();
+      mutate(chatRoomId);
     }
     prevTurnRef.current = greetingTurn;
-  }, [greetingTurn, fire]);
+  }, [greetingTurn, chatRoomId, mutate]);
 
-  // 채팅방 unmount 시 (chatRoomId ref 사용 — stale closure 방지)
+  // 채팅방 unmount 시
   const chatRoomIdRef = useRef(chatRoomId);
   chatRoomIdRef.current = chatRoomId;
   useEffect(() => {
     return () => {
-      chatroomPost.markRead(chatRoomIdRef.current).catch(() => {});
+      chatroomPost
+        .markRead(chatRoomIdRef.current)
+        .then(invalidateChatList)
+        .catch(() => {});
     };
   }, []);
 
@@ -51,7 +53,10 @@ export function useMarkRead({ chatRoomId, historyLength, greetingTurn }: UseMark
   useEffect(() => {
     const handler = () => {
       if (document.visibilityState === 'hidden') {
-        chatroomPost.markRead(chatRoomId).catch(() => {});
+        chatroomPost
+          .markRead(chatRoomId)
+          .then(invalidateChatList)
+          .catch(() => {});
       }
     };
     document.addEventListener('visibilitychange', handler);

--- a/apps/peelie-web/src/features/chatroom/hooks/useSendChatMessage.ts
+++ b/apps/peelie-web/src/features/chatroom/hooks/useSendChatMessage.ts
@@ -1,149 +1,18 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
 
-import { chatroomQueries } from '@/entities/chatroom';
-import type { ChatBubble, LocalTurn } from '@/entities/chatroom';
-
-import { streamChatMessage } from '../api/streamChatMessage';
-
-type State =
-  | { status: 'idle' }
-  | { status: 'sending'; userMessage: string }
-  | {
-      status: 'streaming';
-      chatRoomId: string;
-      userMessage: string;
-      bubbles: ChatBubble[];
-      suggestions: string[];
-    }
-  | { status: 'error'; message: string };
-
-type Action =
-  | { type: 'SEND'; userMessage: string }
-  | { type: 'META'; chatRoomId: string }
-  | { type: 'APPEND_BUBBLE'; bubble: ChatBubble }
-  | { type: 'SET_SUGGESTIONS'; suggestions: string[] }
-  | { type: 'ERROR'; message: string }
-  | { type: 'RESET' };
-
-const initialState: State = { status: 'idle' };
-
-function reducer(state: State, action: Action): State {
-  switch (action.type) {
-    case 'SEND':
-      return { status: 'sending', userMessage: action.userMessage };
-    case 'META':
-      if (state.status !== 'sending') return state;
-      return {
-        status: 'streaming',
-        chatRoomId: action.chatRoomId,
-        userMessage: state.userMessage,
-        bubbles: [],
-        suggestions: [],
-      };
-    case 'APPEND_BUBBLE':
-      if (state.status !== 'streaming') return state;
-      return { ...state, bubbles: [...state.bubbles, action.bubble] };
-    case 'SET_SUGGESTIONS':
-      if (state.status !== 'streaming') return state;
-      return { ...state, suggestions: action.suggestions };
-    case 'ERROR':
-      return { status: 'error', message: action.message };
-    case 'RESET':
-      return initialState;
-    default:
-      return state;
-  }
-}
+import { chatStreamStore, sendMessage } from '../model/chatStreamStore';
 
 export function useSendChatMessage(chatRoomId: string) {
-  const [state, dispatch] = useReducer(reducer, initialState);
-  const [history, setHistory] = useState<LocalTurn[]>([]);
-  const abortRef = useRef<AbortController | null>(null);
+  const snapshot = useSyncExternalStore(chatStreamStore.subscribe, chatStreamStore.getSnapshot);
   const queryClient = useQueryClient();
-  const isBusy = state.status === 'sending' || state.status === 'streaming';
+
+  const entry = snapshot.get(chatRoomId) ?? { state: { status: 'idle' as const }, history: [] };
 
   const send = useCallback(
-    async (message: string) => {
-      const trimmed = message.trim();
-      if (!trimmed) return;
-      if (isBusy) return;
-
-      const controller = new AbortController();
-      abortRef.current = controller;
-      dispatch({ type: 'SEND', userMessage: trimmed });
-
-      // 스트림 처리 진실 저장소. dispatch 직후 reducer state 동기 read 안 함.
-      const acc = {
-        userMessage: trimmed,
-        bubbles: [] as ChatBubble[],
-        suggestions: [] as string[],
-      };
-      let completed: LocalTurn | null = null;
-      let errored = false;
-
-      try {
-        await streamChatMessage(
-          chatRoomId,
-          trimmed,
-          (event) => {
-            switch (event.type) {
-              case 'meta':
-                dispatch({ type: 'META', chatRoomId: event.chatRoomId });
-                return;
-              case 'bubble': {
-                const bubble: ChatBubble = { text: event.text, delayMs: event.delayMs };
-                acc.bubbles.push(bubble);
-                dispatch({ type: 'APPEND_BUBBLE', bubble });
-                return;
-              }
-              case 'suggestions':
-                acc.suggestions = event.suggestions;
-                dispatch({ type: 'SET_SUGGESTIONS', suggestions: event.suggestions });
-                return;
-              case 'done':
-                completed = {
-                  kind: 'send',
-                  userMessage: acc.userMessage,
-                  bubbles: acc.bubbles,
-                  suggestions: acc.suggestions,
-                  completedAt: new Date().toISOString(),
-                };
-                return;
-              case 'error':
-                errored = true;
-                toast.error(event.message);
-                dispatch({ type: 'ERROR', message: event.message });
-                return;
-              case 'skip':
-                // send 흐름엔 안 옴
-                return;
-            }
-          },
-          controller.signal,
-        );
-      } catch (e) {
-        if (controller.signal.aborted) return;
-        errored = true;
-        const msg = e instanceof Error ? e.message : '메시지 전송에 실패했습니다.';
-        toast.error(msg);
-        dispatch({ type: 'ERROR', message: msg });
-        return;
-      }
-
-      if (completed && !errored) {
-        const turn = completed;
-        setHistory((prev) => [...prev, turn]);
-        dispatch({ type: 'RESET' });
-        queryClient.invalidateQueries({ queryKey: chatroomQueries.chatList.queryKey });
-        queryClient.invalidateQueries({ queryKey: chatroomQueries.rooms.queryKey });
-      }
-    },
-    [chatRoomId, isBusy, queryClient],
+    (message: string) => sendMessage(chatRoomId, message, queryClient),
+    [chatRoomId, queryClient],
   );
 
-  useEffect(() => () => abortRef.current?.abort(), []);
-
-  return { state, history, send };
+  return { state: entry.state, history: entry.history, send };
 }

--- a/apps/peelie-web/src/features/chatroom/model/chatStreamStore.ts
+++ b/apps/peelie-web/src/features/chatroom/model/chatStreamStore.ts
@@ -1,0 +1,185 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { chatroomQueries } from '@/entities/chatroom';
+import type { ChatBubble, LocalTurn } from '@/entities/chatroom';
+
+import { streamChatMessage } from '../api/streamChatMessage';
+
+type State =
+  | { status: 'idle' }
+  | { status: 'sending'; userMessage: string }
+  | {
+      status: 'streaming';
+      chatRoomId: string;
+      userMessage: string;
+      bubbles: ChatBubble[];
+      suggestions: string[];
+    }
+  | { status: 'error'; message: string };
+
+type Action =
+  | { type: 'SEND'; userMessage: string }
+  | { type: 'META'; chatRoomId: string }
+  | { type: 'APPEND_BUBBLE'; bubble: ChatBubble }
+  | { type: 'SET_SUGGESTIONS'; suggestions: string[] }
+  | { type: 'ERROR'; message: string };
+
+export type SendStreamState = State;
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'SEND':
+      return { status: 'sending', userMessage: action.userMessage };
+    case 'META':
+      if (state.status !== 'sending') return state;
+      return {
+        status: 'streaming',
+        chatRoomId: action.chatRoomId,
+        userMessage: state.userMessage,
+        bubbles: [],
+        suggestions: [],
+      };
+    case 'APPEND_BUBBLE':
+      if (state.status !== 'streaming') return state;
+      return { ...state, bubbles: [...state.bubbles, action.bubble] };
+    case 'SET_SUGGESTIONS':
+      if (state.status !== 'streaming') return state;
+      return { ...state, suggestions: action.suggestions };
+    case 'ERROR':
+      return { status: 'error', message: action.message };
+    default:
+      return state;
+  }
+}
+
+interface StreamEntry {
+  state: State;
+  history: LocalTurn[];
+}
+
+const entries = new Map<string, StreamEntry>();
+const controllers = new Map<string, AbortController>();
+const listeners = new Set<() => void>();
+let snapshot: ReadonlyMap<string, StreamEntry> = new Map();
+
+function notify() {
+  snapshot = new Map(entries);
+  listeners.forEach((l) => l());
+}
+
+function getOrCreate(chatRoomId: string): StreamEntry {
+  let entry = entries.get(chatRoomId);
+  if (!entry) {
+    entry = { state: { status: 'idle' }, history: [] };
+    entries.set(chatRoomId, entry);
+  }
+  return entry;
+}
+
+function applyAction(chatRoomId: string, action: Action) {
+  const entry = getOrCreate(chatRoomId);
+  const next = reducer(entry.state, action);
+  if (next !== entry.state) {
+    entries.set(chatRoomId, { ...entry, state: next });
+    notify();
+  }
+}
+
+export async function sendMessage(
+  chatRoomId: string,
+  message: string,
+  queryClient: QueryClient,
+): Promise<void> {
+  const entry = getOrCreate(chatRoomId);
+  const { status } = entry.state;
+  if (status === 'sending' || status === 'streaming') return;
+
+  const trimmed = message.trim();
+  if (!trimmed) return;
+
+  const controller = new AbortController();
+  controllers.set(chatRoomId, controller);
+
+  applyAction(chatRoomId, { type: 'SEND', userMessage: trimmed });
+
+  const acc = {
+    userMessage: trimmed,
+    bubbles: [] as ChatBubble[],
+    suggestions: [] as string[],
+  };
+  let completed: LocalTurn | null = null;
+  let errored = false;
+
+  try {
+    await streamChatMessage(
+      chatRoomId,
+      trimmed,
+      (event) => {
+        switch (event.type) {
+          case 'meta':
+            applyAction(chatRoomId, { type: 'META', chatRoomId: event.chatRoomId });
+            return;
+          case 'bubble': {
+            const bubble: ChatBubble = { text: event.text, delayMs: event.delayMs };
+            acc.bubbles.push(bubble);
+            applyAction(chatRoomId, { type: 'APPEND_BUBBLE', bubble });
+            return;
+          }
+          case 'suggestions':
+            acc.suggestions = event.suggestions;
+            applyAction(chatRoomId, { type: 'SET_SUGGESTIONS', suggestions: event.suggestions });
+            return;
+          case 'done':
+            completed = {
+              kind: 'send',
+              userMessage: acc.userMessage,
+              bubbles: acc.bubbles,
+              suggestions: acc.suggestions,
+              completedAt: new Date().toISOString(),
+            };
+            return;
+          case 'error':
+            errored = true;
+            toast.error(event.message);
+            applyAction(chatRoomId, { type: 'ERROR', message: event.message });
+            return;
+          case 'skip':
+            return;
+        }
+      },
+      controller.signal,
+    );
+  } catch (e) {
+    if (controller.signal.aborted) return;
+    errored = true;
+    const msg = e instanceof Error ? e.message : '메시지 전송에 실패했습니다.';
+    toast.error(msg);
+    applyAction(chatRoomId, { type: 'ERROR', message: msg });
+    return;
+  } finally {
+    controllers.delete(chatRoomId);
+  }
+
+  if (completed && !errored) {
+    const turn = completed as LocalTurn;
+    const current = getOrCreate(chatRoomId);
+    entries.set(chatRoomId, {
+      state: { status: 'idle' },
+      history: [...current.history, turn],
+    });
+    notify();
+    queryClient.invalidateQueries({ queryKey: chatroomQueries.chatList.queryKey });
+    queryClient.invalidateQueries({ queryKey: chatroomQueries.rooms.queryKey });
+  }
+}
+
+export const chatStreamStore = {
+  subscribe(listener: () => void) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getSnapshot(): ReadonlyMap<string, StreamEntry> {
+    return snapshot;
+  },
+};

--- a/apps/peelie-web/src/features/chatroom/model/greetingStore.ts
+++ b/apps/peelie-web/src/features/chatroom/model/greetingStore.ts
@@ -1,0 +1,103 @@
+import { toast } from 'sonner';
+
+import type { ChatBubble, LocalTurn } from '@/entities/chatroom';
+
+import { streamGreeting } from '../api/streamGreeting';
+
+interface GreetingEntry {
+  turn: LocalTurn | null;
+  pending: boolean;
+  done: boolean;
+}
+
+const entries = new Map<string, GreetingEntry>();
+const listeners = new Set<() => void>();
+let snapshot: ReadonlyMap<string, GreetingEntry> = new Map();
+
+function notify() {
+  snapshot = new Map(entries);
+  listeners.forEach((l) => l());
+}
+
+function getOrCreate(chatRoomId: string): GreetingEntry {
+  let entry = entries.get(chatRoomId);
+  if (!entry) {
+    entry = { turn: null, pending: false, done: false };
+    entries.set(chatRoomId, entry);
+  }
+  return entry;
+}
+
+export function startGreeting(chatRoomId: string): void {
+  const entry = getOrCreate(chatRoomId);
+  if (entry.done || entry.pending) return;
+
+  entries.set(chatRoomId, { ...entry, pending: true });
+  notify();
+
+  const acc = { bubbles: [] as ChatBubble[], suggestions: [] as string[] };
+  let completed: LocalTurn | null = null;
+  let skipped = false;
+  let aborted = false;
+
+  const controller = new AbortController();
+  controller.signal.addEventListener('abort', () => {
+    aborted = true;
+  });
+
+  streamGreeting(
+    chatRoomId,
+    (event) => {
+      switch (event.type) {
+        case 'skip':
+          skipped = true;
+          return;
+        case 'meta':
+          return;
+        case 'bubble':
+          acc.bubbles.push({ text: event.text, delayMs: event.delayMs });
+          return;
+        case 'suggestions':
+          acc.suggestions = event.suggestions;
+          return;
+        case 'done':
+          completed = {
+            kind: 'greeting',
+            bubbles: acc.bubbles,
+            suggestions: acc.suggestions,
+            completedAt: new Date().toISOString(),
+          };
+          return;
+        case 'error':
+          toast.error(event.message);
+          return;
+      }
+    },
+    controller.signal,
+  )
+    .catch((e) => {
+      if (aborted) return;
+      toast.error(e instanceof Error ? e.message : '인사 로딩 실패');
+    })
+    .finally(() => {
+      if (aborted) return;
+      const current = getOrCreate(chatRoomId);
+      entries.set(chatRoomId, {
+        ...current,
+        pending: false,
+        done: true,
+        turn: !skipped && completed ? completed : current.turn,
+      });
+      notify();
+    });
+}
+
+export const greetingStore = {
+  subscribe(listener: () => void) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getSnapshot(): ReadonlyMap<string, GreetingEntry> {
+    return snapshot;
+  },
+};

--- a/apps/peelie-web/src/features/chatroom/ui/AvatarMessage.tsx
+++ b/apps/peelie-web/src/features/chatroom/ui/AvatarMessage.tsx
@@ -3,27 +3,16 @@ import type { ChatBubble } from '@/entities/chatroom';
 import { ChatRoomProfileIcon } from '@/shared/ui/icons/ChatRoomProfileIcon';
 import { cn } from '@/shared/lib/utils';
 
-import { SuggestionList } from './SuggestionList';
-
 interface AvatarMessageProps {
   bubbles: ChatBubble[];
   /** 마지막 버블 옆에만 시간 표시. */
   createdAt: string;
-  suggestions?: string[];
-  /** 있으면 chip 으로 노출 + 클릭 시 호출. 없으면 chip 자체 렌더 안 함. */
-  onSuggestionSelect?: (text: string) => void;
   className?: string;
 }
 
 const BOT_NAME = 'POKI봇';
 
-export function AvatarMessage({
-  bubbles,
-  createdAt,
-  suggestions,
-  onSuggestionSelect,
-  className,
-}: AvatarMessageProps) {
+export function AvatarMessage({ bubbles, createdAt, className }: AvatarMessageProps) {
   if (bubbles.length === 0) return null;
   return (
     <div className={cn('flex flex-col items-start gap-1', className)}>
@@ -40,9 +29,6 @@ export function AvatarMessage({
           createdAt={i === bubbles.length - 1 ? createdAt : undefined}
         />
       ))}
-      {suggestions && suggestions.length > 0 && onSuggestionSelect && (
-        <SuggestionList suggestions={suggestions} onSelect={onSuggestionSelect} />
-      )}
     </div>
   );
 }

--- a/apps/peelie-web/src/features/chatroom/ui/AvatarMessage.tsx
+++ b/apps/peelie-web/src/features/chatroom/ui/AvatarMessage.tsx
@@ -7,12 +7,11 @@ interface AvatarMessageProps {
   bubbles: ChatBubble[];
   /** 마지막 버블 옆에만 시간 표시. */
   createdAt: string;
+  name?: string;
   className?: string;
 }
 
-const BOT_NAME = 'POKI봇';
-
-export function AvatarMessage({ bubbles, createdAt, className }: AvatarMessageProps) {
+export function AvatarMessage({ bubbles, createdAt, name, className }: AvatarMessageProps) {
   if (bubbles.length === 0) return null;
   return (
     <div className={cn('flex flex-col items-start gap-1', className)}>
@@ -20,7 +19,7 @@ export function AvatarMessage({ bubbles, createdAt, className }: AvatarMessagePr
         <div className="relative size-7 shrink-0 overflow-hidden rounded-full bg-gray-01">
           <ChatRoomProfileIcon className="absolute left-1.5 top-1 h-5 w-3.5" />
         </div>
-        <span className="text-body-s-400 text-brand-sub-30">{BOT_NAME}</span>
+        <span className="text-body-s-400 text-brand-sub-30">{name}</span>
       </div>
       {bubbles.map((bubble, i) => (
         <AvatarBubble

--- a/apps/peelie-web/src/features/chatroom/ui/SuggestionList.tsx
+++ b/apps/peelie-web/src/features/chatroom/ui/SuggestionList.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from 'react';
+
 import { cn } from '@/shared/lib/utils';
 import { formatChatTime } from '@/entities/chatroom';
 
@@ -9,6 +11,8 @@ interface SuggestionListProps {
   className?: string;
 }
 
+const SELECT_DELAY_MS = 400;
+
 export function SuggestionList({
   suggestions,
   onSelect,
@@ -16,26 +20,57 @@ export function SuggestionList({
   disabled,
   className,
 }: SuggestionListProps) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleClick = (text: string, i: number) => {
+    if (disabled) return;
+    if (selectedIndex !== null) return;
+    setSelectedIndex(i);
+    timerRef.current = window.setTimeout(() => {
+      onSelect(text);
+    }, SELECT_DELAY_MS);
+  };
+
   if (suggestions.length === 0) return null;
+
   return (
     <div className={cn('flex flex-col items-end gap-2', className)}>
       <div className="flex flex-col items-end gap-1.5">
-        {suggestions.map((text, i) => (
-          <div key={i} className="flex items-center gap-3">
-            <EditIcon className="size-5 text-gray-01" />
-            <button
-              type="button"
-              onClick={() => !disabled && onSelect(text)}
-              disabled={disabled}
+        {suggestions.map((text, i) => {
+          const isSelected = selectedIndex === i;
+          const isFaded = selectedIndex !== null && !isSelected;
+          return (
+            <div
+              key={i}
               className={cn(
-                'min-w-[98px] rounded-small rounded-tr-none bg-gray-10 px-3 py-2',
-                'text-right text-body-m-400 text-text-main',
+                'flex items-center gap-3 transition-all duration-300 ease-out',
+                isFaded && 'translate-y-1 opacity-0',
               )}
             >
-              {text}
-            </button>
-          </div>
-        ))}
+              <EditIcon className="size-5 text-gray-01" />
+              <button
+                type="button"
+                onClick={() => handleClick(text, i)}
+                disabled={disabled || selectedIndex !== null}
+                className={cn(
+                  'min-w-[98px] rounded-small rounded-tr-none px-3 py-2',
+                  'text-right text-body-m-400 text-text-main',
+                  'transition-all duration-300 ease-out',
+                  isSelected ? 'scale-105 bg-brand-30' : 'bg-gray-10',
+                )}
+              >
+                {text}
+              </button>
+            </div>
+          );
+        })}
       </div>
       {createdAt && (
         <time dateTime={createdAt} className="text-caption-m-400 text-gray-39">

--- a/apps/peelie-web/src/features/chatroom/ui/SuggestionList.tsx
+++ b/apps/peelie-web/src/features/chatroom/ui/SuggestionList.tsx
@@ -1,29 +1,67 @@
 import { cn } from '@/shared/lib/utils';
+import { formatChatTime } from '@/entities/chatroom';
 
 interface SuggestionListProps {
   suggestions: string[];
   onSelect: (text: string) => void;
+  createdAt?: string;
+  disabled?: boolean;
   className?: string;
 }
 
-export function SuggestionList({ suggestions, onSelect, className }: SuggestionListProps) {
+export function SuggestionList({
+  suggestions,
+  onSelect,
+  createdAt,
+  disabled,
+  className,
+}: SuggestionListProps) {
   if (suggestions.length === 0) return null;
   return (
-    <div className={cn('mt-1 flex flex-wrap gap-2 pl-8', className)}>
-      {suggestions.map((text, i) => (
-        <button
-          key={i}
-          type="button"
-          onClick={() => onSelect(text)}
-          className={cn(
-            'rounded-full border border-brand-sub-30 bg-white px-3 py-1.5',
-            'text-body-s-400 text-brand-sub-30',
-            'transition-colors hover:bg-brand-sub-30/10 active:bg-brand-sub-30/20',
-          )}
-        >
-          {text}
-        </button>
-      ))}
+    <div className={cn('flex flex-col items-end gap-2', className)}>
+      <div className="flex flex-col items-end gap-1.5">
+        {suggestions.map((text, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <EditIcon className="size-5 text-gray-01" />
+            <button
+              type="button"
+              onClick={() => !disabled && onSelect(text)}
+              disabled={disabled}
+              className={cn(
+                'min-w-[98px] rounded-small rounded-tr-none bg-gray-10 px-3 py-2',
+                'text-right text-body-m-400 text-text-main',
+              )}
+            >
+              {text}
+            </button>
+          </div>
+        ))}
+      </div>
+      {createdAt && (
+        <time dateTime={createdAt} className="text-caption-m-400 text-gray-39">
+          {formatChatTime(createdAt)}
+        </time>
+      )}
     </div>
+  );
+}
+
+function EditIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden
+    >
+      <path
+        d="M14.166 2.5a1.768 1.768 0 0 1 2.5 2.5L6.25 15.417 2.5 16.667l1.25-3.75L14.166 2.5Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }

--- a/apps/peelie-web/src/features/chatroom/ui/SuggestionList.tsx
+++ b/apps/peelie-web/src/features/chatroom/ui/SuggestionList.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useRef, useState } from 'react';
-
 import { cn } from '@/shared/lib/utils';
 import { formatChatTime } from '@/entities/chatroom';
 
@@ -11,8 +9,6 @@ interface SuggestionListProps {
   className?: string;
 }
 
-const SELECT_DELAY_MS = 400;
-
 export function SuggestionList({
   suggestions,
   onSelect,
@@ -20,57 +16,24 @@ export function SuggestionList({
   disabled,
   className,
 }: SuggestionListProps) {
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const timerRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
-    };
-  }, []);
-
-  const handleClick = (text: string, i: number) => {
-    if (disabled) return;
-    if (selectedIndex !== null) return;
-    setSelectedIndex(i);
-    timerRef.current = window.setTimeout(() => {
-      onSelect(text);
-    }, SELECT_DELAY_MS);
-  };
-
   if (suggestions.length === 0) return null;
 
   return (
     <div className={cn('flex flex-col items-end gap-2', className)}>
       <div className="flex flex-col items-end gap-1.5">
-        {suggestions.map((text, i) => {
-          const isSelected = selectedIndex === i;
-          const isFaded = selectedIndex !== null && !isSelected;
-          return (
-            <div
-              key={i}
-              className={cn(
-                'flex items-center gap-3 transition-all duration-300 ease-out',
-                isFaded && 'translate-y-1 opacity-0',
-              )}
+        {suggestions.map((text, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <EditIcon className="size-5 text-gray-01" />
+            <button
+              type="button"
+              onClick={() => !disabled && onSelect(text)}
+              disabled={disabled}
+              className="min-w-[98px] rounded-small rounded-tr-none bg-gray-10 px-3 py-2 text-right text-body-m-400 text-text-main"
             >
-              <EditIcon className="size-5 text-gray-01" />
-              <button
-                type="button"
-                onClick={() => handleClick(text, i)}
-                disabled={disabled || selectedIndex !== null}
-                className={cn(
-                  'min-w-[98px] rounded-small rounded-tr-none px-3 py-2',
-                  'text-right text-body-m-400 text-text-main',
-                  'transition-all duration-300 ease-out',
-                  isSelected ? 'scale-105 bg-brand-30' : 'bg-gray-10',
-                )}
-              >
-                {text}
-              </button>
-            </div>
-          );
-        })}
+              {text}
+            </button>
+          </div>
+        ))}
       </div>
       {createdAt && (
         <time dateTime={createdAt} className="text-caption-m-400 text-gray-39">

--- a/apps/peelie-web/src/global.css
+++ b/apps/peelie-web/src/global.css
@@ -550,17 +550,6 @@ body {
   scrollbar-width: none; /* Firefox */
 }
 
-/* SsgoiLayout이 만드는 div의 스크롤 컨테이너화 해제 */
-main > div[style*="min-height: 100vh"] {
-  overflow: visible !important;
-  min-height: 0 !important;
-}
-
-/* 하단 고정 nav가 콘텐츠 가리지 않게 */
-main {
-  padding-bottom: 64px; /* nav 높이(48px) + 여유 */
-}
-
 /* 채팅 메시지가 하단에서 위로 슬라이드 + fade-in 으로 등장. */
 @keyframes chat-slide-up-in {
   from {

--- a/apps/peelie-web/src/global.css
+++ b/apps/peelie-web/src/global.css
@@ -560,3 +560,19 @@ main > div[style*="min-height: 100vh"] {
 main {
   padding-bottom: 64px; /* nav 높이(48px) + 여유 */
 }
+
+/* 채팅 메시지가 하단에서 위로 슬라이드 + fade-in 으로 등장. */
+@keyframes chat-slide-up-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.chat-slide-up-in {
+  animation: chat-slide-up-in 300ms ease-out;
+}

--- a/apps/peelie-web/src/pages/AiChat/AiChatPage.tsx
+++ b/apps/peelie-web/src/pages/AiChat/AiChatPage.tsx
@@ -4,8 +4,6 @@ import { SsgoiTransition } from '@ssgoi/react';
 
 import { Header } from '@/widgets/header/Header';
 import { ChatRoomCard, useGetChatListQuery } from '@/entities/chatroom';
-import { Button } from '@/shared/ui/common/button';
-import { cn } from '@/shared/lib/utils';
 import PATH from '@/shared/constants/path';
 
 import { SearchInput } from './ui/SearchInput';
@@ -47,12 +45,6 @@ export default function AiChatPage() {
             </li>
           ))}
         </ul>
-        <div className={cn('flex flex-col items-center justify-center min-h-screen', 'gap-4')}>
-          <h1 className="text-title-headline-1 text-gray-99">AI챗</h1>
-          <Button color="tertiary" size="sm" onClick={() => navigate(-1)}>
-            뒤로가기
-          </Button>
-        </div>
       </div>
     </SsgoiTransition>
   );

--- a/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
+++ b/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
@@ -18,6 +18,7 @@ import {
   getRenderItemCreatedAt,
   getRenderItemKey,
   isSameDay,
+  useGetChatListQuery,
   useGetChatMessagesQuery,
   type RenderItem,
   type StreamingState,
@@ -73,6 +74,9 @@ export default function ChatRoomPage() {
 
   const { data: messagesData } = useGetChatMessagesQuery(chatRoomId);
   const initialMessages = messagesData?.data.items ?? [];
+
+  const { data: chatListData } = useGetChatListQuery();
+  const currentRoom = chatListData?.data.find((r) => r.chatRoomId === chatRoomId);
 
   const { turn: greetingTurn, pending: greetingPending } = useGreeting(chatRoomId);
   const { state: sendState, history, send } = useSendChatMessage(chatRoomId);
@@ -203,7 +207,10 @@ export default function ChatRoomPage() {
       />
       <div className="relative flex min-h-dvh w-full flex-col">
         <div className="sticky top-0 z-10 shrink-0 bg-gray-99/30 backdrop-blur-md">
-          <ChatRoomHeader />
+          <ChatRoomHeader
+            name={currentRoom?.friend.name}
+            personality={currentRoom?.friend.personality}
+          />
         </div>
 
         <div className="flex flex-1 flex-col justify-end gap-1 px-4 py-2">

--- a/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
+++ b/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
@@ -25,11 +25,17 @@ import {
 import { ChatRoomHeader } from './ui/ChatRoomHeader';
 
 const NEAR_BOTTOM_THRESHOLD_PX = 80;
-const SUGGESTIONS_DELAY_MS = 500;
+const SUGGESTIONS_DELAY_MS = 1000;
 const ROUTE_SCROLL_CONTAINER_ID = 'route-scroll-container';
 
 function getRouteScrollContainer() {
   return document.getElementById(ROUTE_SCROLL_CONTAINER_ID);
+}
+
+const SMOOTH_SCROLL_DURATION_MS = 600;
+
+function easeOutCubic(t: number) {
+  return 1 - Math.pow(1 - t, 3);
 }
 
 function scrollRouteToBottom(
@@ -37,15 +43,28 @@ function scrollRouteToBottom(
   behavior: ScrollBehavior = 'auto',
   syncAfterTransition = false,
 ) {
-  scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior });
-
-  if (syncAfterTransition) {
-    // ssgoi 는 transition 초반 몇 frame 동안 scroll 저장을 무시한다.
-    // 초기 진입 직후 bottom scroll 이 저장되지 않는 케이스를 막기 위해 한 번 더 동기화한다.
-    window.setTimeout(() => {
-      scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior: 'auto' });
-    }, 200);
+  if (behavior === 'auto') {
+    scrollContainer.scrollTo({ top: scrollContainer.scrollHeight });
+    if (syncAfterTransition) {
+      window.setTimeout(() => {
+        scrollContainer.scrollTo({ top: scrollContainer.scrollHeight });
+      }, 200);
+    }
+    return;
   }
+
+  const start = scrollContainer.scrollTop;
+  const end = scrollContainer.scrollHeight - scrollContainer.clientHeight;
+  const distance = end - start;
+  if (distance <= 0) return;
+
+  const startTime = performance.now();
+  function step(now: number) {
+    const t = Math.min((now - startTime) / SMOOTH_SCROLL_DURATION_MS, 1);
+    scrollContainer.scrollTop = start + distance * easeOutCubic(t);
+    if (t < 1) requestAnimationFrame(step);
+  }
+  requestAnimationFrame(step);
 }
 
 export default function ChatRoomPage() {

--- a/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
+++ b/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
@@ -2,7 +2,12 @@ import { Fragment, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { SsgoiTransition } from '@ssgoi/react';
 
-import { AvatarMessage, useGreeting, useSendChatMessage } from '@/features/chatroom';
+import {
+  AvatarMessage,
+  SuggestionList,
+  useGreeting,
+  useSendChatMessage,
+} from '@/features/chatroom';
 import {
   buildRenderItems,
   ChatInput,
@@ -120,12 +125,16 @@ function renderItem(item: RenderItem, onSuggestionSelect: (text: string) => void
         );
       }
       return (
-        <AvatarMessage
-          bubbles={message.bubbles}
-          createdAt={message.createdAt}
-          suggestions={isLastAvatarTurn ? message.suggestions : undefined}
-          onSuggestionSelect={isLastAvatarTurn ? onSuggestionSelect : undefined}
-        />
+        <>
+          <AvatarMessage bubbles={message.bubbles} createdAt={message.createdAt} />
+          {isLastAvatarTurn && message.suggestions.length > 0 && (
+            <SuggestionList
+              suggestions={message.suggestions}
+              onSelect={onSuggestionSelect}
+              createdAt={message.createdAt}
+            />
+          )}
+        </>
       );
     }
     case 'streaming-user':
@@ -135,13 +144,18 @@ function renderItem(item: RenderItem, onSuggestionSelect: (text: string) => void
         </div>
       );
     case 'streaming-avatar':
-      // 스트리밍 중에는 suggestions 받았더라도 클릭 막음 (isBusy 인 상태이므로 노출만)
       return (
-        <AvatarMessage
-          bubbles={item.bubbles}
-          createdAt={item.createdAt}
-          suggestions={item.suggestions.length > 0 ? item.suggestions : undefined}
-        />
+        <>
+          <AvatarMessage bubbles={item.bubbles} createdAt={item.createdAt} />
+          {item.suggestions.length > 0 && (
+            <SuggestionList
+              suggestions={item.suggestions}
+              onSelect={onSuggestionSelect}
+              createdAt={item.createdAt}
+              disabled
+            />
+          )}
+        </>
       );
   }
 }

--- a/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
+++ b/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
@@ -195,7 +195,7 @@ export default function ChatRoomPage() {
 
   const handleSuggestionSelect = (text: string) => {
     if (isBusy) return;
-    send(text);
+    setInput(text);
   };
 
   return (
@@ -228,7 +228,12 @@ export default function ChatRoomPage() {
             return (
               <Fragment key={getRenderItemKey(item, i)}>
                 {showDate && <DateSeparator date={getRenderItemCreatedAt(item)} />}
-                {renderItem(item, handleSuggestionSelect, delayedSuggestionsId)}
+                {renderItem(
+                  item,
+                  handleSuggestionSelect,
+                  delayedSuggestionsId,
+                  currentRoom?.friend.name,
+                )}
               </Fragment>
             );
           })}
@@ -251,6 +256,7 @@ function renderItem(
   item: RenderItem,
   onSuggestionSelect: (text: string) => void,
   delayedSuggestionsId: string | null,
+  name: string | undefined,
 ) {
   switch (item.kind) {
     case 'message': {
@@ -266,7 +272,7 @@ function renderItem(
         isLastAvatarTurn && message.suggestions.length > 0 && delayedSuggestionsId === message.id;
       return (
         <>
-          <AvatarMessage bubbles={message.bubbles} createdAt={message.createdAt} />
+          <AvatarMessage bubbles={message.bubbles} createdAt={message.createdAt} name={name} />
           {showSuggestions && (
             <SuggestionList
               suggestions={message.suggestions}
@@ -286,8 +292,10 @@ function renderItem(
     case 'streaming-avatar':
       // streaming 중 suggestions 가 도착해도 여기선 표시하지 않는다.
       // done 직후 history 로 들어간 message 의 suggestions 가 0.5s 지연 후 표시됨.
-      return <AvatarMessage bubbles={item.bubbles} createdAt={item.createdAt} />;
+      return <AvatarMessage bubbles={item.bubbles} createdAt={item.createdAt} name={name} />;
     case 'streaming-placeholder':
-      return <AvatarTypingBubble showHeader={item.showHeader} className="chat-slide-up-in" />;
+      return (
+        <AvatarTypingBubble showHeader={item.showHeader} name={name} className="chat-slide-up-in" />
+      );
   }
 }

--- a/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
+++ b/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
@@ -6,6 +6,7 @@ import {
   AvatarMessage,
   SuggestionList,
   useGreeting,
+  useMarkRead,
   useSendChatMessage,
 } from '@/features/chatroom';
 import {
@@ -75,6 +76,8 @@ export default function ChatRoomPage() {
 
   const { turn: greetingTurn, pending: greetingPending } = useGreeting(chatRoomId);
   const { state: sendState, history, send } = useSendChatMessage(chatRoomId);
+
+  useMarkRead({ chatRoomId, historyLength: history.length, greetingTurn });
 
   const [input, setInput] = useState('');
 

--- a/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
+++ b/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { SsgoiTransition } from '@ssgoi/react';
 
@@ -9,6 +9,7 @@ import {
   useSendChatMessage,
 } from '@/features/chatroom';
 import {
+  AvatarTypingBubble,
   buildRenderItems,
   ChatInput,
   DateSeparator,
@@ -23,13 +24,16 @@ import {
 
 import { ChatRoomHeader } from './ui/ChatRoomHeader';
 
+const NEAR_BOTTOM_THRESHOLD_PX = 80;
+const SUGGESTIONS_DELAY_MS = 500;
+
 export default function ChatRoomPage() {
   const { chatRoomId = '' } = useParams<{ chatRoomId: string }>();
 
   const { data: messagesData } = useGetChatMessagesQuery(chatRoomId);
   const initialMessages = messagesData?.data.items ?? [];
 
-  const { turn: greetingTurn } = useGreeting(chatRoomId);
+  const { turn: greetingTurn, pending: greetingPending } = useGreeting(chatRoomId);
   const { state: sendState, history, send } = useSendChatMessage(chatRoomId);
 
   const [input, setInput] = useState('');
@@ -57,10 +61,80 @@ export default function ChatRoomPage() {
         greetingTurn,
         history,
         streaming,
+        greetingPending,
         nowIso: new Date().toISOString(),
       }),
-    [initialMessages, greetingTurn, history, streaming],
+    [initialMessages, greetingTurn, history, streaming, greetingPending],
   );
+
+  // 표시 대상 suggestions 의 ID (마지막 AVATAR message 의 suggestions 가 있을 때).
+  // streaming-avatar 의 suggestions 는 idle 전환 후 history 메시지로 옮겨와 처리하므로 여기선 무시.
+  const targetSuggestionsId = useMemo(() => {
+    for (let i = items.length - 1; i >= 0; i--) {
+      const it = items[i];
+      if (it.kind === 'message' && it.isLastAvatarTurn && it.message.suggestions.length > 0) {
+        return it.message.id;
+      }
+    }
+    return null;
+  }, [items]);
+
+  const [delayedSuggestionsId, setDelayedSuggestionsId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!targetSuggestionsId) {
+      setDelayedSuggestionsId(null);
+      return;
+    }
+    const id = setTimeout(
+      () => setDelayedSuggestionsId(targetSuggestionsId),
+      SUGGESTIONS_DELAY_MS,
+    );
+    return () => clearTimeout(id);
+  }, [targetSuggestionsId]);
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const isInitialScrolledRef = useRef(false);
+  // 사용자가 위로 스크롤하면 false. 그 외엔 true 유지하여 새 메시지에 항상 따라감.
+  const stickToBottomRef = useRef(true);
+
+  useEffect(() => {
+    if (isInitialScrolledRef.current) return;
+    if (!messagesData) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    isInitialScrolledRef.current = true;
+  }, [messagesData]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const handleUserScroll = () => {
+      requestAnimationFrame(() => {
+        const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+        stickToBottomRef.current = distance < NEAR_BOTTOM_THRESHOLD_PX;
+      });
+    };
+    el.addEventListener('wheel', handleUserScroll, { passive: true });
+    el.addEventListener('touchmove', handleUserScroll, { passive: true });
+    return () => {
+      el.removeEventListener('wheel', handleUserScroll);
+      el.removeEventListener('touchmove', handleUserScroll);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isInitialScrolledRef.current) return;
+    if (!stickToBottomRef.current) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    // DOM reflow 직후 측정해야 새 버블 height 까지 반영된 scrollHeight 가 잡힌다.
+    const rafId = requestAnimationFrame(() => {
+      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [items, delayedSuggestionsId]);
 
   const handleSubmit = () => {
     if (!input.trim()) return;
@@ -81,7 +155,10 @@ export default function ChatRoomPage() {
       >
         <ChatRoomHeader />
 
-        <div className="flex flex-1 flex-col gap-1 overflow-y-auto px-4 pb-28 pt-4">
+        <div
+          ref={scrollRef}
+          className="flex flex-1 flex-col gap-1 overflow-y-auto px-4 pb-30 pt-4"
+        >
           <div className="flex justify-center py-2">
             <span className="px-4 py-1 text-caption-m-400 text-gray-01 text-center">
               지금 대화는 AI를 통해 생성되었습니다.
@@ -96,7 +173,7 @@ export default function ChatRoomPage() {
             return (
               <Fragment key={getRenderItemKey(item, i)}>
                 {showDate && <DateSeparator date={getRenderItemCreatedAt(item)} />}
-                {renderItem(item, handleSuggestionSelect)}
+                {renderItem(item, handleSuggestionSelect, delayedSuggestionsId)}
               </Fragment>
             );
           })}
@@ -113,7 +190,11 @@ export default function ChatRoomPage() {
   );
 }
 
-function renderItem(item: RenderItem, onSuggestionSelect: (text: string) => void) {
+function renderItem(
+  item: RenderItem,
+  onSuggestionSelect: (text: string) => void,
+  delayedSuggestionsId: string | null,
+) {
   switch (item.kind) {
     case 'message': {
       const { message, isLastAvatarTurn } = item;
@@ -124,10 +205,14 @@ function renderItem(item: RenderItem, onSuggestionSelect: (text: string) => void
           </div>
         );
       }
+      const showSuggestions =
+        isLastAvatarTurn &&
+        message.suggestions.length > 0 &&
+        delayedSuggestionsId === message.id;
       return (
         <>
           <AvatarMessage bubbles={message.bubbles} createdAt={message.createdAt} />
-          {isLastAvatarTurn && message.suggestions.length > 0 && (
+          {showSuggestions && (
             <SuggestionList
               suggestions={message.suggestions}
               onSelect={onSuggestionSelect}
@@ -139,23 +224,15 @@ function renderItem(item: RenderItem, onSuggestionSelect: (text: string) => void
     }
     case 'streaming-user':
       return (
-        <div className="flex justify-end">
+        <div className="chat-slide-up-in flex justify-end">
           <UserBubble content={item.text} createdAt={item.createdAt} />
         </div>
       );
     case 'streaming-avatar':
-      return (
-        <>
-          <AvatarMessage bubbles={item.bubbles} createdAt={item.createdAt} />
-          {item.suggestions.length > 0 && (
-            <SuggestionList
-              suggestions={item.suggestions}
-              onSelect={onSuggestionSelect}
-              createdAt={item.createdAt}
-              disabled
-            />
-          )}
-        </>
-      );
+      // streaming 중 suggestions 가 도착해도 여기선 표시하지 않는다.
+      // done 직후 history 로 들어간 message 의 suggestions 가 0.5s 지연 후 표시됨.
+      return <AvatarMessage bubbles={item.bubbles} createdAt={item.createdAt} />;
+    case 'streaming-placeholder':
+      return <AvatarTypingBubble showHeader={item.showHeader} className="chat-slide-up-in" />;
   }
 }

--- a/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
+++ b/apps/peelie-web/src/pages/ChatRoom/ChatRoomPage.tsx
@@ -26,6 +26,27 @@ import { ChatRoomHeader } from './ui/ChatRoomHeader';
 
 const NEAR_BOTTOM_THRESHOLD_PX = 80;
 const SUGGESTIONS_DELAY_MS = 500;
+const ROUTE_SCROLL_CONTAINER_ID = 'route-scroll-container';
+
+function getRouteScrollContainer() {
+  return document.getElementById(ROUTE_SCROLL_CONTAINER_ID);
+}
+
+function scrollRouteToBottom(
+  scrollContainer: HTMLElement,
+  behavior: ScrollBehavior = 'auto',
+  syncAfterTransition = false,
+) {
+  scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior });
+
+  if (syncAfterTransition) {
+    // ssgoi 는 transition 초반 몇 frame 동안 scroll 저장을 무시한다.
+    // 초기 진입 직후 bottom scroll 이 저장되지 않는 케이스를 막기 위해 한 번 더 동기화한다.
+    window.setTimeout(() => {
+      scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior: 'auto' });
+    }, 200);
+  }
+}
 
 export default function ChatRoomPage() {
   const { chatRoomId = '' } = useParams<{ chatRoomId: string }>();
@@ -86,14 +107,10 @@ export default function ChatRoomPage() {
       setDelayedSuggestionsId(null);
       return;
     }
-    const id = setTimeout(
-      () => setDelayedSuggestionsId(targetSuggestionsId),
-      SUGGESTIONS_DELAY_MS,
-    );
+    const id = setTimeout(() => setDelayedSuggestionsId(targetSuggestionsId), SUGGESTIONS_DELAY_MS);
     return () => clearTimeout(id);
   }, [targetSuggestionsId]);
 
-  const scrollRef = useRef<HTMLDivElement | null>(null);
   const isInitialScrolledRef = useRef(false);
   // 사용자가 위로 스크롤하면 false. 그 외엔 true 유지하여 새 메시지에 항상 따라감.
   const stickToBottomRef = useRef(true);
@@ -101,37 +118,45 @@ export default function ChatRoomPage() {
   useEffect(() => {
     if (isInitialScrolledRef.current) return;
     if (!messagesData) return;
-    const el = scrollRef.current;
-    if (!el) return;
-    el.scrollTop = el.scrollHeight;
-    isInitialScrolledRef.current = true;
+
+    const scrollContainer = getRouteScrollContainer();
+    if (!scrollContainer) return;
+
+    const rafId = requestAnimationFrame(() => {
+      scrollRouteToBottom(scrollContainer, 'auto', true);
+      isInitialScrolledRef.current = true;
+    });
+
+    return () => cancelAnimationFrame(rafId);
   }, [messagesData]);
 
   useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
+    const scrollContainer = getRouteScrollContainer();
+    if (!scrollContainer) return;
+
     const handleUserScroll = () => {
       requestAnimationFrame(() => {
-        const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+        const distance =
+          scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight;
         stickToBottomRef.current = distance < NEAR_BOTTOM_THRESHOLD_PX;
       });
     };
-    el.addEventListener('wheel', handleUserScroll, { passive: true });
-    el.addEventListener('touchmove', handleUserScroll, { passive: true });
+
+    scrollContainer.addEventListener('scroll', handleUserScroll, { passive: true });
+
     return () => {
-      el.removeEventListener('wheel', handleUserScroll);
-      el.removeEventListener('touchmove', handleUserScroll);
+      scrollContainer.removeEventListener('scroll', handleUserScroll);
     };
   }, []);
 
   useEffect(() => {
     if (!isInitialScrolledRef.current) return;
     if (!stickToBottomRef.current) return;
-    const el = scrollRef.current;
-    if (!el) return;
     // DOM reflow 직후 측정해야 새 버블 height 까지 반영된 scrollHeight 가 잡힌다.
     const rafId = requestAnimationFrame(() => {
-      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+      const scrollContainer = getRouteScrollContainer();
+      if (!scrollContainer) return;
+      scrollRouteToBottom(scrollContainer, 'smooth');
     });
     return () => cancelAnimationFrame(rafId);
   }, [items, delayedSuggestionsId]);
@@ -148,17 +173,18 @@ export default function ChatRoomPage() {
   };
 
   return (
-    <SsgoiTransition id="/chat-room">
+    <SsgoiTransition id={`/chat-room/${chatRoomId}`}>
       <div
-        className="flex h-screen w-full flex-col bg-cover bg-center"
+        aria-hidden
+        className="fixed inset-0 bg-cover bg-center"
         style={{ backgroundImage: 'url(/chatroom-background.png)' }}
-      >
-        <ChatRoomHeader />
+      />
+      <div className="relative flex min-h-dvh w-full flex-col">
+        <div className="sticky top-0 z-10 shrink-0 bg-gray-99/30 backdrop-blur-md">
+          <ChatRoomHeader />
+        </div>
 
-        <div
-          ref={scrollRef}
-          className="flex flex-1 flex-col gap-1 overflow-y-auto px-4 pb-30 pt-4"
-        >
+        <div className="flex flex-1 flex-col justify-end gap-1 px-4 py-2">
           <div className="flex justify-center py-2">
             <span className="px-4 py-1 text-caption-m-400 text-gray-01 text-center">
               지금 대화는 AI를 통해 생성되었습니다.
@@ -184,6 +210,8 @@ export default function ChatRoomPage() {
           onChange={(e) => setInput(e.target.value)}
           onSubmit={handleSubmit}
           disabled={isBusy}
+          position="static"
+          className="sticky bottom-0 z-10 shrink-0"
         />
       </div>
     </SsgoiTransition>
@@ -206,9 +234,7 @@ function renderItem(
         );
       }
       const showSuggestions =
-        isLastAvatarTurn &&
-        message.suggestions.length > 0 &&
-        delayedSuggestionsId === message.id;
+        isLastAvatarTurn && message.suggestions.length > 0 && delayedSuggestionsId === message.id;
       return (
         <>
           <AvatarMessage bubbles={message.bubbles} createdAt={message.createdAt} />

--- a/apps/peelie-web/src/pages/ChatRoom/ui/ChatRoomHeader.tsx
+++ b/apps/peelie-web/src/pages/ChatRoom/ui/ChatRoomHeader.tsx
@@ -1,8 +1,16 @@
 import { useNavigate } from 'react-router-dom';
+
+import { PERSONALITY_LABEL } from '@/entities/chatroom';
+import type { PersonalityType } from '@/entities/chatroom';
 import { AlermIcon } from '@/shared/ui/icons/AlermIcon';
 import { ChatRoomProfileIcon } from '@/shared/ui/icons/ChatRoomProfileIcon';
 
-export function ChatRoomHeader() {
+interface ChatRoomHeaderProps {
+  name?: string;
+  personality?: PersonalityType;
+}
+
+export function ChatRoomHeader({ name, personality }: ChatRoomHeaderProps) {
   const navigate = useNavigate();
 
   return (
@@ -36,8 +44,12 @@ export function ChatRoomHeader() {
 
             {/* 이름 + 유형 */}
             <div className="flex flex-col">
-              <span className="text-caption-m-400 text-brand-50">친구 유형</span>
-              <span className="text-body-m-500 text-gray-01">김나은</span>
+              {personality && (
+                <span className="text-caption-m-400 text-brand-50">
+                  {PERSONALITY_LABEL[personality]}
+                </span>
+              )}
+              {name && <span className="text-body-m-500 text-gray-01">{name}</span>}
             </div>
           </div>
         </div>


### PR DESCRIPTION
 ## Summary
- 채팅방 스크롤/전환 안정성 개선
- sse 메시지 전송과 greeting 상태 채팅방 단위 store로 분리
- 읽음 처리 연동, unread UI, 추천 답변 입력 흐름 개선

## Detail
route scroll container를 기준으로 채팅방 스크롤을 관리해 뒤로가기 시 스크롤이 상단으로 튀는 문제 수정
메시지 전송 SSE와 greeting SSE를 store로 분리해 화면 이탈 후에도 진행 상태와 완료 history 가 유지되게 작업
채팅방 읽음 처리 API/mutation/hook을 추가하고, 메시지 완료/인사 완료/이탈/탭 비활성화 시 읽음 처리 호출
추천 답변 클릭 동작을 즉시 전송에서 입력창 반영으로 변경
